### PR TITLE
Integration of TMD 7 into tablecloth

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,6 @@
 {:extra-paths ["data"]
  :deps {org.clojure/clojure              {:mvn/version "1.11.1"}
-        techascent/tech.ml.dataset       {:mvn/version "6.103"}
-        ;; techascent/tech.ml.dataset       {:mvn/version "7.000-beta-3"}
+        techascent/tech.ml.dataset       {:mvn/version "7.000-beta-5"}
         ;; generateme/fastmath {:mvn/version "2.1.0"}
         }
  :aliases {:dev {:extra-deps {org.scicloj/clay {:mvn/version "1-alpha10"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:extra-paths ["data"]
  :deps {org.clojure/clojure              {:mvn/version "1.11.1"}
-        techascent/tech.ml.dataset       {:mvn/version "7.000-beta-5"}
+        techascent/tech.ml.dataset       {:mvn/version "7.000-beta-6"}
         ;; generateme/fastmath {:mvn/version "2.1.0"}
         }
  :aliases {:dev {:extra-deps {org.scicloj/clay {:mvn/version "1-alpha10"}}}}}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject scicloj/tablecloth "6.103.1"
+(defproject scicloj/tablecloth "7.000-beta-1"
   :description "Dataset manipulation library built on the top of tech.ml.dataset."
   :url "https://github.com/scicloj/tablecloth"
   :license {:name "The MIT Licence"

--- a/src/tablecloth/api/dataset.clj
+++ b/src/tablecloth/api/dataset.clj
@@ -2,11 +2,11 @@
   (:refer-clojure :exclude [concat])
   (:require [tech.v3.dataset :as ds]
             [tech.v3.dataset.column :as col]
-            [tech.v3.protocols.dataset :as prot]
+            [tech.v3.dataset.protocols :as prot]
             [tech.v3.dataset.print :as p]
             [tech.v3.tensor :as tensor]
             [tech.v3.dataset.tensor :as ds-tensor]
-            
+
             [tablecloth.api.utils :refer [iterable-sequence? grouped? mark-as-group map-inst?]])
   (:import [java.io FileNotFoundException]))
 
@@ -17,7 +17,7 @@
 (defn dataset?
   "Is `ds` a `dataset` type?"
   [ds]
-  (satisfies? prot/PColumnarDataset ds))
+  (prot/is-dataset? ds))
 
 (defn empty-ds?
   [ds]
@@ -48,7 +48,7 @@
 
 (defn dataset
   "Create `dataset`.
-  
+
   Dataset can be created from:
 
   * map of values and/or sequences


### PR DESCRIPTION
API mainly unchanged - 

```console
FAIL aggregate default prefix changed to custom at (aggregate_test.clj:23)
Expected:
(:xxx-sum-of-b :$group-name)
Actual:
(:$group-name :xxx-sum-of-b)
Diffs: in [0] expected :xxx-sum-of-b, was :$group-name
              in [1] expected :$group-name, was :xxx-sum-of-b

FAIL replace missing values in grouped dataset at (missing_test.clj:141)
Expected:
[[1.0 2022.0 "Barry Buddon" 49]
 [0.0 2023.0 "Barry Buddon" 49]
 [2.4 2024.0 "Barry Buddon" 49]
 [3.2 2022.0 "Tentsmuir Woods" 49]
 [0.0 2023.0 "Tentsmuir Woods" 49]
 [1.4 2024.0 "Tentsmuir Woods" 49]]
Actual:
#<tech.v3.dataset.impl.dataset.Dataset$reify__23482@3c33b673>
Diffs: in [0 0] expected 1.0, was 2022.0
              in [0 1] expected 2022.0, was 49
              in [0 3] expected 49, was 1.0
              in [1 0] expected 0.0, was 2023.0
              in [1 1] expected 2023.0, was 49
              in [1 3] expected 49, was 0.0
              in [2 0] expected 2.4, was 2024.0
              in [2 1] expected 2024.0, was 49
              in [2 3] expected 49, was 2.4
              in [3 0] expected 3.2, was 2022.0
              in [3 1] expected 2022.0, was 49
              in [3 3] expected 49, was 3.2
              in [4 0] expected 0.0, was 2023.0
              in [4 1] expected 2023.0, was 49
              in [4 3] expected 49, was 0.0
              in [5 0] expected 1.4, was 2024.0
              in [5 1] expected 2024.0, was 49
              in [5 3] expected 49, was 1.4
nil
FAILURE: 2 checks failed.  (But 260 succeeded.)
``` 
 