### PR TITLE
print-dataset with options now returns a string

### DIFF
--- a/src/tablecloth/api/dataset.clj
+++ b/src/tablecloth/api/dataset.clj
@@ -162,7 +162,7 @@
   tech.v3.dataset.print/dataset-data->str
 "
   ([ds] (println (p/dataset->str ds)))
-  ([ds options] (println (p/dataset->str ds options))))
+  ([ds options] (p/dataset->str ds options)))
 
 ;;
 


### PR DESCRIPTION
Was side effecting via println