### PR TITLE
Consolidate tablecloth.column.api/operators args

### DIFF
--- a/src/tablecloth/column/api/lift_operators.clj
+++ b/src/tablecloth/column/api/lift_operators.clj
@@ -6,13 +6,8 @@
     '+
     '-
     '/
-    '<
-    '<=
-    '>
-    '>=
     'abs
     'acos
-    'and
     'asin
     'atan
     'atan2
@@ -31,11 +26,6 @@
     'ceil
     'cos
     'cosh
-    'distance
-    'distance-squared
-    'dot-product
-    'eq
-    'equals
     'exp
     'expm1
     'floor
@@ -52,9 +42,7 @@
     'min
     'next-down
     'next-up
-    'normalize
-    'not-eq
-    'or
+
     'pow
     'quot
     'rem
@@ -81,8 +69,8 @@
     'median] (fn [fn-sym fn-meta]
               (lift-op
                fn-sym fn-meta
-               {:new-args '([col] [col options])
-                :new-args-lookup {'data 'col
+               {:new-args '([x] [x options])
+                :new-args-lookup {'data 'x
                                   'options 'options}}))
    ['even?
     'finite?
@@ -170,7 +158,41 @@
                  fn-sym fn-meta
                  {:new-args '([x] [x options])
                   :new-args-lookup {'data 'x
-                                    'options 'options}}))})
+                                    'options 'options}}))
+   ['normalize] (fn [fn-sym fn-meta]
+                  (lift-op
+                   fn-sym fn-meta
+                   {:new-args '([x])
+                    :new-args-lookup {'item 'x}}))
+   ['<
+    '<=
+    '>
+    '>=] (fn [fn-sym fn-meta]
+           (lift-op
+            fn-sym fn-meta
+            {:new-args '([x y z])
+             :new-args-lookup {'lhs 'x
+                               'mid 'y
+                               'rhs 'z}}))
+   ['equals] (fn [fn-sym fn-meta]
+               (lift-op
+                fn-sym fn-meta
+                {:new-args '([x y & args])
+                 :new-args-lookup {'lhs 'x
+                                   'rhs 'y
+                                   'args 'args}}))
+   ['distance
+    'dot-product
+    'eq
+    'not-eq
+    'or
+    'distance-squared
+    'and] (fn [fn-sym fn-meta]
+            (lift-op
+             fn-sym fn-meta
+             {:new-args '([x y])
+              :new-args-lookup {'lhs 'x
+                                'rhs 'y}}))})
 
 
 (defn deserialize-lift-fn-lookup []

--- a/src/tablecloth/column/api/lift_operators.clj
+++ b/src/tablecloth/column/api/lift_operators.clj
@@ -170,7 +170,7 @@
     '>=] (fn [fn-sym fn-meta]
            (lift-op
             fn-sym fn-meta
-            {:new-args '([x y z])
+            {:new-args '([x y] [x y z])
              :new-args-lookup {'lhs 'x
                                'mid 'y
                                'rhs 'z}}))
@@ -215,3 +215,29 @@
              unsigned-bit-shift-right zero?]
            "src/tablecloth/column/api/operators.clj")
   ,)
+
+
+(comment
+
+  (def mylift (fn [fn-sym fn-meta]
+           (lift-op
+            fn-sym fn-meta
+            {:new-args '([x y z])
+             :new-args-lookup {'lhs 'x
+                               'mid 'y
+                               'rhs 'z}})))
+
+  (def mappings (ns-publics 'tech.v3.datatype.functional))
+
+  (mylift 'tech.v3.datatype.functional/> (meta (get mappings '>)))
+  ;; => (defn
+  ;;     >
+  ;;     ""
+  ;;     ([x y z]
+  ;;      (let
+  ;;       [original-result__31399__auto__
+  ;;        (tech.v3.datatype.functional/> x z)]
+  ;;       (tablecloth.column.api.utils/return-scalar-or-column
+  ;;        original-result__31399__auto__))))
+
+  )

--- a/src/tablecloth/column/api/lift_operators.clj
+++ b/src/tablecloth/column/api/lift_operators.clj
@@ -69,9 +69,8 @@
     'median] (fn [fn-sym fn-meta]
               (lift-op
                fn-sym fn-meta
-               {:new-args '([x] [x options])
-                :new-args-lookup {'data 'x
-                                  'options 'options}}))
+               {:new-args {'[x] {'data 'x}
+                           '[x options] {'data 'x}}}))
    ['even?
     'finite?
     'infinite?
@@ -86,101 +85,85 @@
    (fn [fn-sym fn-meta]
              (lift-op
               fn-sym fn-meta
-              {:new-args '([x] [x options])
-               :new-args-lookup {'arg 'x
-                                 'options 'options}}))
+              {:new-args {'[x] {'arg 'x}
+                          '[x options] {'arg 'x}}}))
    ['percentiles] (fn [fn-sym fn-meta]
                     (lift-op
                      fn-sym fn-meta
-                     {:new-args '([x percentiles] [x percentiles options])
-                      :new-args-lookup {'data 'x,
-                                        'percentages 'percentiles,
-                                        'options 'options}}))
+                     {:new-args {'[x percentiles] {'data 'x
+                                                   'percentages 'percentiles}
+                                 '[x percentiles options] {'data 'x
+                                                           'percentages 'percentiles}}}))
    ['shift] (fn [fn-sym fn-meta]
               (lift-op
                fn-sym fn-meta
-               {:new-args '([x n])
-                :new-args-lookup {'rdr 'x
-                                  'n 'n}}))
+               {:new-args {'[x n] {'rdr 'x}}}))
    ['descriptive-statistics] (fn [fn-sym fn-meta]
                               (lift-op
                                fn-sym fn-meta
-                               {:new-args '([x stats-names stats-data options]
-                                            [x stats-names options]
-                                            [x stats-names]
-                                            [x])
-                                :new-args-lookup {'rdr 'x
-                                                  'src-rdr 'x
-                                                  'stats-names 'stats-names
-                                                  'stats-data 'stats-data
-                                                  'options 'options}}))
+                               {:new-args {'[x] {'rdr 'x}
+                                           '[x stats-names] {'rdr 'x}
+                                           '[x stats-names options] {'rdr 'x}
+                                           '[x stats-names stats-data options] {'src-rdr 'x}}}))
    ['quartiles] (fn [fn-sym fn-meta]
                   (lift-op
                    fn-sym fn-meta
-                   {:new-args '([x options] [x])
-                    :new-args-lookup {'item 'x
-                                      'options 'options}}))
+                   {:new-args {'[x] {'item 'x}
+                               '[x options] {'item 'x}}}))
    ['fill-range] (fn [fn-sym fn-meta]
                   (lift-op
                    fn-sym fn-meta
-                   {:new-args '([x max-span])
-                    :new-args-lookup {'numeric-data 'x
-                                      'max-span 'max-span}}))
+                   {:new-args {'[x max-span] {'numeric-data 'x}}}))
    ['reduce-min
     'reduce-max
     'reduce-*
     'reduce-+] (fn [fn-sym fn-meta]
                  (lift-op
+
                   fn-sym fn-meta
-                  {:new-args '([x])
-                   :new-args-lookup {'rdr 'x}}))
+                  {:new-args {'[x] {'rdr 'x}}}))
   ['mean-fast
    'sum-fast
    'magnitude-squared] (fn [fn-sym fn-meta]
                          (lift-op
                           fn-sym fn-meta
-                          {:new-args '([x])
-                           :new-args-lookup {'data 'x}}))
+                          {:new-args {'[x] {'data 'x}}}))
    ['kendalls-correlation
     'pearsons-correlation
     'spearmans-correlation] (fn [fn-sym fn-meta]
                               (lift-op
                                fn-sym fn-meta
-                               {:new-args '([x y] [x y options])
-                                :new-args-lookup {'lhs 'x
-                                                  'rhs 'y
-                                                  'options 'options}}))
+                               {:new-args {'[x y] {'lhs 'x
+                                                   'rhs 'y}
+                                           '[x y options] {'lhs 'x
+                                                           'rhs 'y}}}))
    ['cumprod
     'cumsum
     'cummax
     'cummin] (fn [fn-sym fn-meta]
                 (lift-op
                  fn-sym fn-meta
-                 {:new-args '([x] [x options])
-                  :new-args-lookup {'data 'x
-                                    'options 'options}}))
+                 {:new-args {'[x] {'data 'x}}}))
    ['normalize] (fn [fn-sym fn-meta]
                   (lift-op
                    fn-sym fn-meta
-                   {:new-args '([x])
-                    :new-args-lookup {'item 'x}}))
+                   {:new-args {'[x] {'item 'x}}}))
    ['<
     '<=
     '>
     '>=] (fn [fn-sym fn-meta]
            (lift-op
             fn-sym fn-meta
-            {:new-args '([x y] [x y z])
-             :new-args-lookup {'lhs 'x
-                               'mid 'y
-                               'rhs 'z}}))
+            {:new-args {'[x y] {'lhs 'x
+                                'rhs 'y}
+                        '[x y z] {'lhs 'x
+                                  'mid 'y
+                                  'rhs 'z}}}))
    ['equals] (fn [fn-sym fn-meta]
                (lift-op
                 fn-sym fn-meta
-                {:new-args '([x y & args])
-                 :new-args-lookup {'lhs 'x
-                                   'rhs 'y
-                                   'args 'args}}))
+                {:new-args {'[x y & args] {'lhs 'x
+                                           'rhs 'y}}}))
    ['distance
     'dot-product
     'eq
@@ -190,9 +173,8 @@
     'and] (fn [fn-sym fn-meta]
             (lift-op
              fn-sym fn-meta
-             {:new-args '([x y])
-              :new-args-lookup {'lhs 'x
-                                'rhs 'y}}))})
+             {:new-args {'[x y] {'lhs 'x
+                                 'rhs 'y}}}))})
 
 
 (defn deserialize-lift-fn-lookup []
@@ -222,7 +204,12 @@
   (def mylift (fn [fn-sym fn-meta]
            (lift-op
             fn-sym fn-meta
-            {:new-args '([x y z])
+            {:new-args {'[x y] {'lhs 'x
+                                'rhs 'y}
+                        '[x y z] {'lhs 'x
+                                  'mid 'y
+                                  'rhs 'z}}}
+            #_{:new-args '([x y z])
              :new-args-lookup {'lhs 'x
                                'mid 'y
                                'rhs 'z}})))
@@ -230,14 +217,7 @@
   (def mappings (ns-publics 'tech.v3.datatype.functional))
 
   (mylift 'tech.v3.datatype.functional/> (meta (get mappings '>)))
-  ;; => (defn
-  ;;     >
-  ;;     ""
-  ;;     ([x y z]
-  ;;      (let
-  ;;       [original-result__31399__auto__
-  ;;        (tech.v3.datatype.functional/> x z)]
-  ;;       (tablecloth.column.api.utils/return-scalar-or-column
-  ;;        original-result__31399__auto__))))
+
+  tech.v3.datatype.functional/>
 
   )

--- a/src/tablecloth/column/api/operators.clj
+++ b/src/tablecloth/column/api/operators.clj
@@ -43,1647 +43,1616 @@
 (defn
  kurtosis
  ""
- ([col]
+ ([x]
   (let
-   [original-result__44239__auto__
-    (tech.v3.datatype.functional/kurtosis col)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/kurtosis x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
- ([col options]
+    original-result__31399__auto__)))
+ ([x options]
   (let
-   [original-result__44239__auto__
-    (tech.v3.datatype.functional/kurtosis col options)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/kurtosis x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  bit-set
  ""
  ([x y]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/bit-set x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply tech.v3.datatype.functional/bit-set x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  finite?
  ""
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/finite? x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/finite? x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  distance
  ""
- ([lhs rhs]
+ ([x y]
   (let
-   [original-result__44240__auto__
-    (tech.v3.datatype.functional/distance lhs rhs)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/distance x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  reduce-min
  ""
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/reduce-min x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  to-radians
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/to-radians x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/to-radians x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  bit-shift-right
  ""
  ([x y]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/bit-shift-right x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply
      tech.v3.datatype.functional/bit-shift-right
      x
      y
      args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  ieee-remainder
  ""
  ([x y]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/ieee-remainder x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply
      tech.v3.datatype.functional/ieee-remainder
      x
      y
      args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  log
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/log x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__ (tech.v3.datatype.functional/log x)]
+   [original-result__31400__auto__ (tech.v3.datatype.functional/log x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  bit-shift-left
  ""
  ([x y]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/bit-shift-left x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply
      tech.v3.datatype.functional/bit-shift-left
      x
      y
      args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  acos
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/acos x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/acos x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  to-degrees
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/to-degrees x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/to-degrees x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  <
  ""
- ([lhs mid rhs]
+ ([x y z]
   (let
-   [original-result__44240__auto__
-    (tech.v3.datatype.functional/< lhs mid rhs)]
+   [original-result__31399__auto__ (tech.v3.datatype.functional/< x z)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
- ([lhs rhs]
-  (let
-   [original-result__44240__auto__
-    (tech.v3.datatype.functional/< lhs rhs)]
-   (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  floor
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/floor x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/floor x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  atan2
  ""
  ([x y]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/atan2 x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply tech.v3.datatype.functional/atan2 x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  normalize
  ""
- ([item]
+ ([x]
   (let
-   [original-result__44240__auto__
-    (tech.v3.datatype.functional/normalize item)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/normalize x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  hypot
  ""
  ([x y]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/hypot x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply tech.v3.datatype.functional/hypot x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  tanh
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/tanh x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/tanh x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  sq
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/sq x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__ (tech.v3.datatype.functional/sq x)]
+   [original-result__31400__auto__ (tech.v3.datatype.functional/sq x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  fill-range
  "Given a reader of numeric data and a max span amount, produce\n  a new reader where the difference between any two consecutive elements\n  is less than or equal to the max span amount.  Also return a bitmap of the added\n  indexes.  Uses linear interpolation to fill in areas, operates in double space.\n  Returns\n  {:result :missing}"
  ([x max-span]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/fill-range x max-span)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  sum
  "Double sum of data using\n  [Kahan compensated summation](https://en.wikipedia.org/wiki/Kahan_summation_algorithm)."
- ([col]
+ ([x]
   (let
-   [original-result__44239__auto__
-    (tech.v3.datatype.functional/sum col)]
+   [original-result__31399__auto__ (tech.v3.datatype.functional/sum x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
- ([col options]
+    original-result__31399__auto__)))
+ ([x options]
   (let
-   [original-result__44239__auto__
-    (tech.v3.datatype.functional/sum col options)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/sum x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  pos?
  ""
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/pos? x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/pos? x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  shift
  "Shift by n and fill in with the first element for n>0 or last element for n<0.\n\n  Examples:\n\n```clojure\nuser> (dfn/shift (range 10) 2)\n[0 0 0 1 2 3 4 5 6 7]\nuser> (dfn/shift (range 10) -2)\n[2 3 4 5 6 7 8 9 9 9]\n```"
  ([x n]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/shift x n)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  ceil
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/ceil x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/ceil x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  bit-xor
  ""
  ([x y]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/bit-xor x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply tech.v3.datatype.functional/bit-xor x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  unsigned-bit-shift-right
  ""
  ([x y]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/unsigned-bit-shift-right x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply
      tech.v3.datatype.functional/unsigned-bit-shift-right
      x
      y
      args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  neg?
  ""
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/neg? x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/neg? x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  <=
  ""
- ([lhs mid rhs]
+ ([x y z]
   (let
-   [original-result__44240__auto__
-    (tech.v3.datatype.functional/<= lhs mid rhs)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/<= x z)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
- ([lhs rhs]
-  (let
-   [original-result__44240__auto__
-    (tech.v3.datatype.functional/<= lhs rhs)]
-   (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  *
  ""
  ([x y]
   (let
-   [original-result__44240__auto__ (tech.v3.datatype.functional/* x y)]
+   [original-result__31400__auto__ (tech.v3.datatype.functional/* x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply tech.v3.datatype.functional/* x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  min
  ""
  ([x]
   (let
-   [original-result__44240__auto__ (tech.v3.datatype.functional/min x)]
+   [original-result__31400__auto__ (tech.v3.datatype.functional/min x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/min x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply tech.v3.datatype.functional/min x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  atan
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/atan x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/atan x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  mathematical-integer?
  ""
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/mathematical-integer? x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/mathematical-integer? x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  cumprod
  "Cumulative running product; returns result in double space.\n\n  Options:\n\n  * `:nan-strategy` - one of `:keep`, `:remove`, `:exception`.  Defaults to `:remove`."
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/cumprod x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/cumprod options x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  expm1
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/expm1 x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/expm1 x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  identity
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/identity x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/identity x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  reduce-max
  ""
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/reduce-max x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  cumsum
  "Cumulative running summation; returns result in double space.\n\n  Options:\n\n  * `:nan-strategy` - one of `:keep`, `:remove`, `:exception`.  Defaults to `:remove`."
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/cumsum x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/cumsum options x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  descriptive-statistics
  "Calculate a set of descriptive statistics on a single reader.\n\n  Available stats:\n  #{:min :quartile-1 :sum :mean :mode :median :quartile-3 :max\n    :variance :standard-deviation :skew :n-elems :kurtosis}\n\n  options\n    - `:nan-strategy` - defaults to :remove, one of\n    [:keep :remove :exception]. The fastest option is :keep but this\n    may result in your results having NaN's in them.  You can also pass\n  in a double predicate to filter custom double values."
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/descriptive-statistics x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x stats-names]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/descriptive-statistics stats-names x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x stats-names options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/descriptive-statistics
      stats-names
      options
      x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x stats-names stats-data options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/descriptive-statistics
      stats-names
      stats-data
      options
      x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  nan?
  ""
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/nan? x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/nan? x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  bit-and-not
  ""
  ([x y]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/bit-and-not x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply
      tech.v3.datatype.functional/bit-and-not
      x
      y
      args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  logistic
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/logistic x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/logistic x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  cos
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/cos x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__ (tech.v3.datatype.functional/cos x)]
+   [original-result__31400__auto__ (tech.v3.datatype.functional/cos x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  log10
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/log10 x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/log10 x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  quot
  ""
  ([x y]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/quot x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply tech.v3.datatype.functional/quot x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  dot-product
  ""
- ([lhs rhs]
+ ([x y]
   (let
-   [original-result__44240__auto__
-    (tech.v3.datatype.functional/dot-product lhs rhs)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/dot-product x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  tan
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/tan x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__ (tech.v3.datatype.functional/tan x)]
+   [original-result__31400__auto__ (tech.v3.datatype.functional/tan x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  cbrt
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/cbrt x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/cbrt x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  eq
  ""
- ([lhs rhs]
+ ([x y]
   (let
-   [original-result__44240__auto__
-    (tech.v3.datatype.functional/eq lhs rhs)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/eq x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  mean
  "double mean of data"
- ([col]
+ ([x]
   (let
-   [original-result__44239__auto__
-    (tech.v3.datatype.functional/mean col)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/mean x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
- ([col options]
+    original-result__31399__auto__)))
+ ([x options]
   (let
-   [original-result__44239__auto__
-    (tech.v3.datatype.functional/mean col options)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/mean x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  >
  ""
- ([lhs mid rhs]
+ ([x y z]
   (let
-   [original-result__44240__auto__
-    (tech.v3.datatype.functional/> lhs mid rhs)]
+   [original-result__31399__auto__ (tech.v3.datatype.functional/> x z)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
- ([lhs rhs]
-  (let
-   [original-result__44240__auto__
-    (tech.v3.datatype.functional/> lhs rhs)]
-   (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  not-eq
  ""
- ([lhs rhs]
+ ([x y]
   (let
-   [original-result__44240__auto__
-    (tech.v3.datatype.functional/not-eq lhs rhs)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/not-eq x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  even?
  ""
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/even? x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/even? x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  spearmans-correlation
  ""
  ([x y]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/spearmans-correlation x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x y options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/spearmans-correlation options x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  sqrt
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/sqrt x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/sqrt x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  reduce-*
  ""
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/reduce-* x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  next-down
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/next-down x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/next-down x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  -
  ""
  ([x]
   (let
-   [original-result__44240__auto__ (tech.v3.datatype.functional/- x)]
+   [original-result__31400__auto__ (tech.v3.datatype.functional/- x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y]
   (let
-   [original-result__44240__auto__ (tech.v3.datatype.functional/- x y)]
+   [original-result__31400__auto__ (tech.v3.datatype.functional/- x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply tech.v3.datatype.functional/- x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  or
  ""
- ([lhs rhs]
+ ([x y]
   (let
-   [original-result__44240__auto__
-    (tech.v3.datatype.functional/or lhs rhs)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/or x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  distance-squared
  ""
- ([lhs rhs]
+ ([x y]
   (let
-   [original-result__44240__auto__
-    (tech.v3.datatype.functional/distance-squared lhs rhs)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/distance-squared x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  pow
  ""
  ([x y]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/pow x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply tech.v3.datatype.functional/pow x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  next-up
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/next-up x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/next-up x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  skew
  ""
- ([col]
+ ([x]
   (let
-   [original-result__44239__auto__
-    (tech.v3.datatype.functional/skew col)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/skew x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
- ([col options]
+    original-result__31399__auto__)))
+ ([x options]
   (let
-   [original-result__44239__auto__
-    (tech.v3.datatype.functional/skew col options)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/skew x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  exp
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/exp x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__ (tech.v3.datatype.functional/exp x)]
+   [original-result__31400__auto__ (tech.v3.datatype.functional/exp x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  mean-fast
  "Take the mean of the data.  This operation doesn't know anything about nan hence it is\n  a bit faster than the base [[mean]] fn."
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/mean-fast x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  zero?
  ""
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/zero? x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/zero? x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  rem
  ""
  ([x y]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/rem x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply tech.v3.datatype.functional/rem x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  cosh
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/cosh x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/cosh x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  variance
  ""
- ([col]
+ ([x]
   (let
-   [original-result__44239__auto__
-    (tech.v3.datatype.functional/variance col)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/variance x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
- ([col options]
+    original-result__31399__auto__)))
+ ([x options]
   (let
-   [original-result__44239__auto__
-    (tech.v3.datatype.functional/variance col options)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/variance x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  reduce-+
  ""
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/reduce-+ x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  get-significand
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/get-significand x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/get-significand x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  bit-and
  ""
  ([x y]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/bit-and x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply tech.v3.datatype.functional/bit-and x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  kendalls-correlation
  ""
  ([x y]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/kendalls-correlation x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x y options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/kendalls-correlation options x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  not
  ""
  ([x]
   (let
-   [original-result__44239__auto__ (tech.v3.datatype.functional/not x)]
+   [original-result__31399__auto__ (tech.v3.datatype.functional/not x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/not x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  standard-deviation
  ""
- ([col]
+ ([x]
   (let
-   [original-result__44239__auto__
-    (tech.v3.datatype.functional/standard-deviation col)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/standard-deviation x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
- ([col options]
+    original-result__31399__auto__)))
+ ([x options]
   (let
-   [original-result__44239__auto__
-    (tech.v3.datatype.functional/standard-deviation col options)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/standard-deviation x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  cummin
  "Cumulative running min; returns result in double space.\n\n  Options:\n\n  * `:nan-strategy` - one of `:keep`, `:remove`, `:exception`.  Defaults to `:remove`."
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/cummin x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/cummin options x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  magnitude
  ""
  ([item _options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/magnitude item _options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([item]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/magnitude item)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  cummax
  "Cumulative running max; returns result in double space.\n\n  Options:\n\n  * `:nan-strategy` - one of `:keep`, `:remove`, `:exception`.  Defaults to `:remove`."
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/cummax x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/cummax options x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  /
  ""
  ([x]
   (let
-   [original-result__44240__auto__ (tech.v3.datatype.functional// x)]
+   [original-result__31400__auto__ (tech.v3.datatype.functional// x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y]
   (let
-   [original-result__44240__auto__ (tech.v3.datatype.functional// x y)]
+   [original-result__31400__auto__ (tech.v3.datatype.functional// x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply tech.v3.datatype.functional// x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  bit-or
  ""
  ([x y]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/bit-or x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply tech.v3.datatype.functional/bit-or x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  equals
  ""
- ([lhs rhs & args]
+ ([x y & args]
   (let
-   [original-result__44240__auto__
-    (clojure.core/apply
-     tech.v3.datatype.functional/equals
-     lhs
-     rhs
-     args)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/equals x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  >=
  ""
- ([lhs mid rhs]
+ ([x y z]
   (let
-   [original-result__44240__auto__
-    (tech.v3.datatype.functional/>= lhs mid rhs)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/>= x z)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
- ([lhs rhs]
-  (let
-   [original-result__44240__auto__
-    (tech.v3.datatype.functional/>= lhs rhs)]
-   (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  bit-flip
  ""
  ([x y]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/bit-flip x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply tech.v3.datatype.functional/bit-flip x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  log1p
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/log1p x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/log1p x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  asin
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/asin x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/asin x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  quartiles
  "return [min, 25 50 75 max] of item"
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/quartiles x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/quartiles options x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  quartile-3
  ""
- ([col]
+ ([x]
   (let
-   [original-result__44239__auto__
-    (tech.v3.datatype.functional/quartile-3 col)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/quartile-3 x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
- ([col options]
+    original-result__31399__auto__)))
+ ([x options]
   (let
-   [original-result__44239__auto__
-    (tech.v3.datatype.functional/quartile-3 col options)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/quartile-3 x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  infinite?
  ""
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/infinite? x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/infinite? x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  round
  "Vectorized implementation of Math/round.  Operates in double space\n  but returns a long or long reader."
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/round x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/round x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  quartile-1
  ""
- ([col]
+ ([x]
   (let
-   [original-result__44239__auto__
-    (tech.v3.datatype.functional/quartile-1 col)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/quartile-1 x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
- ([col options]
+    original-result__31399__auto__)))
+ ([x options]
   (let
-   [original-result__44239__auto__
-    (tech.v3.datatype.functional/quartile-1 col options)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/quartile-1 x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  odd?
  ""
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/odd? x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/odd? x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  bit-clear
  ""
  ([x y]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/bit-clear x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply
      tech.v3.datatype.functional/bit-clear
      x
      y
      args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  +
  ""
  ([x]
   (let
-   [original-result__44240__auto__ (tech.v3.datatype.functional/+ x)]
+   [original-result__31400__auto__ (tech.v3.datatype.functional/+ x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y]
   (let
-   [original-result__44240__auto__ (tech.v3.datatype.functional/+ x y)]
+   [original-result__31400__auto__ (tech.v3.datatype.functional/+ x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply tech.v3.datatype.functional/+ x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  abs
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/abs x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__ (tech.v3.datatype.functional/abs x)]
+   [original-result__31400__auto__ (tech.v3.datatype.functional/abs x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  median
  ""
- ([col]
+ ([x]
   (let
-   [original-result__44239__auto__
-    (tech.v3.datatype.functional/median col)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/median x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
- ([col options]
+    original-result__31399__auto__)))
+ ([x options]
   (let
-   [original-result__44239__auto__
-    (tech.v3.datatype.functional/median col options)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/median x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  pearsons-correlation
  ""
  ([x y]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/pearsons-correlation x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x y options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/pearsons-correlation options x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  sinh
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/sinh x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/sinh x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  rint
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/rint x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/rint x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  bit-not
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/bit-not x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/bit-not x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  max
  ""
  ([x]
   (let
-   [original-result__44240__auto__ (tech.v3.datatype.functional/max x)]
+   [original-result__31400__auto__ (tech.v3.datatype.functional/max x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/max x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x y & args]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (clojure.core/apply tech.v3.datatype.functional/max x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  ulp
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/ulp x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__ (tech.v3.datatype.functional/ulp x)]
+   [original-result__31400__auto__ (tech.v3.datatype.functional/ulp x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  percentiles
  "Create a reader of percentile values, one for each percentage passed in.\n  Estimation types are in the set of #{:r1,r2...legacy} and are described\n  here: https://commons.apache.org/proper/commons-math/javadocs/api-3.3/index.html.\n\n  nan-strategy can be one of [:keep :remove :exception] and defaults to :exception."
  ([x percentiles]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/percentiles percentiles x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__)))
+    original-result__31399__auto__)))
  ([x percentiles options]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/percentiles percentiles options x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  sin
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/sin x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__ (tech.v3.datatype.functional/sin x)]
+   [original-result__31400__auto__ (tech.v3.datatype.functional/sin x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  sum-fast
  "Find the sum of the data.  This operation is neither nan-aware nor does it implement\n  kahans compensation although via parallelization it implements pairwise summation\n  compensation.  For a more but slightly slower but far more correct sum operator,\n  use [[sum]]."
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/sum-fast x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  signum
  ""
  ([x options]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/signum x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__)))
+    original-result__31400__auto__)))
  ([x]
   (let
-   [original-result__44240__auto__
+   [original-result__31400__auto__
     (tech.v3.datatype.functional/signum x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31400__auto__))))
 
 (defn
  magnitude-squared
  ""
  ([x]
   (let
-   [original-result__44239__auto__
+   [original-result__31399__auto__
     (tech.v3.datatype.functional/magnitude-squared x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44239__auto__))))
+    original-result__31399__auto__))))
 
 (defn
  and
  ""
- ([lhs rhs]
+ ([x y]
   (let
-   [original-result__44240__auto__
-    (tech.v3.datatype.functional/and lhs rhs)]
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/and x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__44240__auto__))))
+    original-result__31399__auto__))))
 

--- a/src/tablecloth/column/api/operators.clj
+++ b/src/tablecloth/column/api/operators.clj
@@ -234,9 +234,15 @@
 (defn
  <
  ""
- ([x y z]
+ ([x y]
   (let
    [original-result__31399__auto__ (tech.v3.datatype.functional/< x z)]
+   (tablecloth.column.api.utils/return-scalar-or-column
+    original-result__31399__auto__)))
+ ([x y z]
+  (let
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/< x y z)]
    (tablecloth.column.api.utils/return-scalar-or-column
     original-result__31399__auto__))))
 
@@ -451,10 +457,16 @@
 (defn
  <=
  ""
- ([x y z]
+ ([x y]
   (let
    [original-result__31399__auto__
     (tech.v3.datatype.functional/<= x z)]
+   (tablecloth.column.api.utils/return-scalar-or-column
+    original-result__31399__auto__)))
+ ([x y z]
+  (let
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/<= x y z)]
    (tablecloth.column.api.utils/return-scalar-or-column
     original-result__31399__auto__))))
 
@@ -804,9 +816,15 @@
 (defn
  >
  ""
- ([x y z]
+ ([x y]
   (let
    [original-result__31399__auto__ (tech.v3.datatype.functional/> x z)]
+   (tablecloth.column.api.utils/return-scalar-or-column
+    original-result__31399__auto__)))
+ ([x y z]
+  (let
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/> x y z)]
    (tablecloth.column.api.utils/return-scalar-or-column
     original-result__31399__auto__))))
 
@@ -1257,10 +1275,16 @@
 (defn
  >=
  ""
- ([x y z]
+ ([x y]
   (let
    [original-result__31399__auto__
     (tech.v3.datatype.functional/>= x z)]
+   (tablecloth.column.api.utils/return-scalar-or-column
+    original-result__31399__auto__)))
+ ([x y z]
+  (let
+   [original-result__31399__auto__
+    (tech.v3.datatype.functional/>= x y z)]
    (tablecloth.column.api.utils/return-scalar-or-column
     original-result__31399__auto__))))
 

--- a/src/tablecloth/column/api/operators.clj
+++ b/src/tablecloth/column/api/operators.clj
@@ -45,1638 +45,1614 @@
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/kurtosis x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/kurtosis x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  bit-set
  ""
  ([x y]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/bit-set x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply tech.v3.datatype.functional/bit-set x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  finite?
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/finite? x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/finite? x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  distance
  ""
  ([x y]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/distance x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  reduce-min
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/reduce-min x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  to-radians
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/to-radians x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/to-radians x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  bit-shift-right
  ""
  ([x y]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/bit-shift-right x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply
      tech.v3.datatype.functional/bit-shift-right
      x
      y
      args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  ieee-remainder
  ""
  ([x y]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/ieee-remainder x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply
      tech.v3.datatype.functional/ieee-remainder
      x
      y
      args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  log
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/log x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__ (tech.v3.datatype.functional/log x)]
+   [original-result__34673__auto__ (tech.v3.datatype.functional/log x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  bit-shift-left
  ""
  ([x y]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/bit-shift-left x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply
      tech.v3.datatype.functional/bit-shift-left
      x
      y
      args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  acos
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/acos x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/acos x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  to-degrees
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/to-degrees x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/to-degrees x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  <
  ""
  ([x y]
   (let
-   [original-result__31399__auto__ (tech.v3.datatype.functional/< x z)]
+   [original-result__34672__auto__ (tech.v3.datatype.functional/< x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x y z]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/< x y z)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  floor
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/floor x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/floor x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  atan2
  ""
  ([x y]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/atan2 x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply tech.v3.datatype.functional/atan2 x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  normalize
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/normalize x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  hypot
  ""
  ([x y]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/hypot x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply tech.v3.datatype.functional/hypot x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  tanh
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/tanh x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/tanh x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  sq
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/sq x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__ (tech.v3.datatype.functional/sq x)]
+   [original-result__34673__auto__ (tech.v3.datatype.functional/sq x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  fill-range
  "Given a reader of numeric data and a max span amount, produce\n  a new reader where the difference between any two consecutive elements\n  is less than or equal to the max span amount.  Also return a bitmap of the added\n  indexes.  Uses linear interpolation to fill in areas, operates in double space.\n  Returns\n  {:result :missing}"
  ([x max-span]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/fill-range x max-span)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  sum
  "Double sum of data using\n  [Kahan compensated summation](https://en.wikipedia.org/wiki/Kahan_summation_algorithm)."
  ([x]
   (let
-   [original-result__31399__auto__ (tech.v3.datatype.functional/sum x)]
+   [original-result__34672__auto__ (tech.v3.datatype.functional/sum x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/sum x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  pos?
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/pos? x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/pos? x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  shift
  "Shift by n and fill in with the first element for n>0 or last element for n<0.\n\n  Examples:\n\n```clojure\nuser> (dfn/shift (range 10) 2)\n[0 0 0 1 2 3 4 5 6 7]\nuser> (dfn/shift (range 10) -2)\n[2 3 4 5 6 7 8 9 9 9]\n```"
  ([x n]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/shift x n)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  ceil
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/ceil x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/ceil x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  bit-xor
  ""
  ([x y]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/bit-xor x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply tech.v3.datatype.functional/bit-xor x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  unsigned-bit-shift-right
  ""
  ([x y]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/unsigned-bit-shift-right x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply
      tech.v3.datatype.functional/unsigned-bit-shift-right
      x
      y
      args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  neg?
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/neg? x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/neg? x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  <=
  ""
  ([x y]
   (let
-   [original-result__31399__auto__
-    (tech.v3.datatype.functional/<= x z)]
+   [original-result__34672__auto__
+    (tech.v3.datatype.functional/<= x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x y z]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/<= x y z)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  *
  ""
  ([x y]
   (let
-   [original-result__31400__auto__ (tech.v3.datatype.functional/* x y)]
+   [original-result__34673__auto__ (tech.v3.datatype.functional/* x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply tech.v3.datatype.functional/* x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  min
  ""
  ([x]
   (let
-   [original-result__31400__auto__ (tech.v3.datatype.functional/min x)]
+   [original-result__34673__auto__ (tech.v3.datatype.functional/min x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/min x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply tech.v3.datatype.functional/min x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  atan
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/atan x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/atan x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  mathematical-integer?
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/mathematical-integer? x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/mathematical-integer? x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  cumprod
  "Cumulative running product; returns result in double space.\n\n  Options:\n\n  * `:nan-strategy` - one of `:keep`, `:remove`, `:exception`.  Defaults to `:remove`."
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/cumprod x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
- ([x options]
-  (let
-   [original-result__31399__auto__
-    (tech.v3.datatype.functional/cumprod options x)]
-   (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  expm1
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/expm1 x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/expm1 x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  identity
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/identity x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/identity x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  reduce-max
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/reduce-max x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  cumsum
  "Cumulative running summation; returns result in double space.\n\n  Options:\n\n  * `:nan-strategy` - one of `:keep`, `:remove`, `:exception`.  Defaults to `:remove`."
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/cumsum x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
- ([x options]
-  (let
-   [original-result__31399__auto__
-    (tech.v3.datatype.functional/cumsum options x)]
-   (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  descriptive-statistics
  "Calculate a set of descriptive statistics on a single reader.\n\n  Available stats:\n  #{:min :quartile-1 :sum :mean :mode :median :quartile-3 :max\n    :variance :standard-deviation :skew :n-elems :kurtosis}\n\n  options\n    - `:nan-strategy` - defaults to :remove, one of\n    [:keep :remove :exception]. The fastest option is :keep but this\n    may result in your results having NaN's in them.  You can also pass\n  in a double predicate to filter custom double values."
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/descriptive-statistics x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x stats-names]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/descriptive-statistics stats-names x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x stats-names options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/descriptive-statistics
      stats-names
      options
      x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x stats-names stats-data options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/descriptive-statistics
      stats-names
      stats-data
      options
      x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  nan?
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/nan? x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/nan? x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  bit-and-not
  ""
  ([x y]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/bit-and-not x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply
      tech.v3.datatype.functional/bit-and-not
      x
      y
      args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  logistic
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/logistic x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/logistic x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  cos
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/cos x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__ (tech.v3.datatype.functional/cos x)]
+   [original-result__34673__auto__ (tech.v3.datatype.functional/cos x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  log10
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/log10 x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/log10 x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  quot
  ""
  ([x y]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/quot x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply tech.v3.datatype.functional/quot x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  dot-product
  ""
  ([x y]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/dot-product x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  tan
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/tan x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__ (tech.v3.datatype.functional/tan x)]
+   [original-result__34673__auto__ (tech.v3.datatype.functional/tan x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  cbrt
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/cbrt x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/cbrt x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  eq
  ""
  ([x y]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/eq x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  mean
  "double mean of data"
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/mean x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/mean x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  >
  ""
  ([x y]
   (let
-   [original-result__31399__auto__ (tech.v3.datatype.functional/> x z)]
+   [original-result__34672__auto__ (tech.v3.datatype.functional/> x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x y z]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/> x y z)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  not-eq
  ""
  ([x y]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/not-eq x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  even?
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/even? x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/even? x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  spearmans-correlation
  ""
  ([x y]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/spearmans-correlation x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x y options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/spearmans-correlation options x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  sqrt
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/sqrt x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/sqrt x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  reduce-*
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/reduce-* x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  next-down
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/next-down x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/next-down x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  -
  ""
  ([x]
   (let
-   [original-result__31400__auto__ (tech.v3.datatype.functional/- x)]
+   [original-result__34673__auto__ (tech.v3.datatype.functional/- x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y]
   (let
-   [original-result__31400__auto__ (tech.v3.datatype.functional/- x y)]
+   [original-result__34673__auto__ (tech.v3.datatype.functional/- x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply tech.v3.datatype.functional/- x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  or
  ""
  ([x y]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/or x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  distance-squared
  ""
  ([x y]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/distance-squared x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  pow
  ""
  ([x y]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/pow x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply tech.v3.datatype.functional/pow x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  next-up
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/next-up x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/next-up x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  skew
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/skew x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/skew x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  exp
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/exp x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__ (tech.v3.datatype.functional/exp x)]
+   [original-result__34673__auto__ (tech.v3.datatype.functional/exp x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  mean-fast
  "Take the mean of the data.  This operation doesn't know anything about nan hence it is\n  a bit faster than the base [[mean]] fn."
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/mean-fast x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  zero?
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/zero? x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/zero? x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  rem
  ""
  ([x y]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/rem x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply tech.v3.datatype.functional/rem x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  cosh
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/cosh x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/cosh x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  variance
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/variance x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/variance x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  reduce-+
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/reduce-+ x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  get-significand
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/get-significand x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/get-significand x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  bit-and
  ""
  ([x y]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/bit-and x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply tech.v3.datatype.functional/bit-and x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  kendalls-correlation
  ""
  ([x y]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/kendalls-correlation x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x y options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/kendalls-correlation options x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  not
  ""
  ([x]
   (let
-   [original-result__31399__auto__ (tech.v3.datatype.functional/not x)]
+   [original-result__34672__auto__ (tech.v3.datatype.functional/not x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/not x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  standard-deviation
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/standard-deviation x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/standard-deviation x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  cummin
  "Cumulative running min; returns result in double space.\n\n  Options:\n\n  * `:nan-strategy` - one of `:keep`, `:remove`, `:exception`.  Defaults to `:remove`."
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/cummin x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
- ([x options]
-  (let
-   [original-result__31399__auto__
-    (tech.v3.datatype.functional/cummin options x)]
-   (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  magnitude
  ""
  ([item _options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/magnitude item _options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([item]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/magnitude item)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  cummax
  "Cumulative running max; returns result in double space.\n\n  Options:\n\n  * `:nan-strategy` - one of `:keep`, `:remove`, `:exception`.  Defaults to `:remove`."
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/cummax x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
- ([x options]
-  (let
-   [original-result__31399__auto__
-    (tech.v3.datatype.functional/cummax options x)]
-   (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  /
  ""
  ([x]
   (let
-   [original-result__31400__auto__ (tech.v3.datatype.functional// x)]
+   [original-result__34673__auto__ (tech.v3.datatype.functional// x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y]
   (let
-   [original-result__31400__auto__ (tech.v3.datatype.functional// x y)]
+   [original-result__34673__auto__ (tech.v3.datatype.functional// x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply tech.v3.datatype.functional// x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  bit-or
  ""
  ([x y]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/bit-or x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply tech.v3.datatype.functional/bit-or x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  equals
  ""
  ([x y & args]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/equals x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  >=
  ""
  ([x y]
   (let
-   [original-result__31399__auto__
-    (tech.v3.datatype.functional/>= x z)]
+   [original-result__34672__auto__
+    (tech.v3.datatype.functional/>= x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x y z]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/>= x y z)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  bit-flip
  ""
  ([x y]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/bit-flip x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply tech.v3.datatype.functional/bit-flip x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  log1p
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/log1p x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/log1p x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  asin
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/asin x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/asin x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  quartiles
  "return [min, 25 50 75 max] of item"
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/quartiles x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/quartiles options x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  quartile-3
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/quartile-3 x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/quartile-3 x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  infinite?
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/infinite? x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/infinite? x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  round
  "Vectorized implementation of Math/round.  Operates in double space\n  but returns a long or long reader."
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/round x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/round x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  quartile-1
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/quartile-1 x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/quartile-1 x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  odd?
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/odd? x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/odd? x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  bit-clear
  ""
  ([x y]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/bit-clear x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply
      tech.v3.datatype.functional/bit-clear
      x
      y
      args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  +
  ""
  ([x]
   (let
-   [original-result__31400__auto__ (tech.v3.datatype.functional/+ x)]
+   [original-result__34673__auto__ (tech.v3.datatype.functional/+ x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y]
   (let
-   [original-result__31400__auto__ (tech.v3.datatype.functional/+ x y)]
+   [original-result__34673__auto__ (tech.v3.datatype.functional/+ x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply tech.v3.datatype.functional/+ x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  abs
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/abs x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__ (tech.v3.datatype.functional/abs x)]
+   [original-result__34673__auto__ (tech.v3.datatype.functional/abs x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  median
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/median x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/median x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  pearsons-correlation
  ""
  ([x y]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/pearsons-correlation x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x y options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/pearsons-correlation options x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  sinh
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/sinh x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/sinh x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  rint
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/rint x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/rint x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  bit-not
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/bit-not x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/bit-not x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  max
  ""
  ([x]
   (let
-   [original-result__31400__auto__ (tech.v3.datatype.functional/max x)]
+   [original-result__34673__auto__ (tech.v3.datatype.functional/max x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/max x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x y & args]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (clojure.core/apply tech.v3.datatype.functional/max x y args)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  ulp
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/ulp x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__ (tech.v3.datatype.functional/ulp x)]
+   [original-result__34673__auto__ (tech.v3.datatype.functional/ulp x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  percentiles
  "Create a reader of percentile values, one for each percentage passed in.\n  Estimation types are in the set of #{:r1,r2...legacy} and are described\n  here: https://commons.apache.org/proper/commons-math/javadocs/api-3.3/index.html.\n\n  nan-strategy can be one of [:keep :remove :exception] and defaults to :exception."
  ([x percentiles]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/percentiles percentiles x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__)))
+    original-result__34672__auto__)))
  ([x percentiles options]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/percentiles percentiles options x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  sin
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/sin x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__ (tech.v3.datatype.functional/sin x)]
+   [original-result__34673__auto__ (tech.v3.datatype.functional/sin x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  sum-fast
  "Find the sum of the data.  This operation is neither nan-aware nor does it implement\n  kahans compensation although via parallelization it implements pairwise summation\n  compensation.  For a more but slightly slower but far more correct sum operator,\n  use [[sum]]."
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/sum-fast x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  signum
  ""
  ([x options]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/signum x options)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__)))
+    original-result__34673__auto__)))
  ([x]
   (let
-   [original-result__31400__auto__
+   [original-result__34673__auto__
     (tech.v3.datatype.functional/signum x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31400__auto__))))
+    original-result__34673__auto__))))
 
 (defn
  magnitude-squared
  ""
  ([x]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/magnitude-squared x)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 
 (defn
  and
  ""
  ([x y]
   (let
-   [original-result__31399__auto__
+   [original-result__34672__auto__
     (tech.v3.datatype.functional/and x y)]
    (tablecloth.column.api.utils/return-scalar-or-column
-    original-result__31399__auto__))))
+    original-result__34672__auto__))))
 


### PR DESCRIPTION
## Summary

`tablecloth.column.api/operators lifts functions in tech.v3.datatepe.functional. That ns has a variety of arguments. Here I've decided to conslidate the variety of arguments so that all functions will use `x`, `y`, and `z` plus any optional arguments.
 