### PR TITLE
Fix docs deploy check for changes to docs

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Check for changes in docs folder
         id: docs_check
         run: |
-          if  git diff --name-only FETCH_HEAD './docs'; then
+          if  [[ $(git diff --name-only master './docs') ]]; then
             echo "There have been changes to the docs."
             echo "docs_changed=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Check for changes in docs folder
         id: docs_check
         run: |
-          if  [[ $(git diff --name-only master './docs') ]]; then
+          if  [[ $(git diff --name-only ${{ github.event.repository.default_branch }} './docs') ]]; then
             echo "There have been changes to the docs."
             echo "docs_changed=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Check for changes in docs folder
         id: docs_check
         run: |
-          if  [[ $(git diff --name-only ${{ github.event.repository.default_branch }} -- './docs') ]]; then
+          if  [[ $(git diff --name-only origin/${{ github.event.repository.default_branch }} -- './docs') ]]; then
             echo "There have been changes to the docs."
             echo "docs_changed=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,13 +12,24 @@ on:
 concurrency: build-and-deploy-${{ github.ref }}
 
 jobs:
-  deploy-docs:
+  check-for-doc-changes:
     runs-on: ubuntu-latest
 
-    # Only run this job if there were changes in the docs folder
-    paths:
-      - ./docs/*
-    
+    steps:
+      - name: Check for changes in docs folder
+        id: docs_check
+        run: |
+	  if git diff --quiet HEAD^ HEAD --name-only | grep -q '^docs/'; then
+            echo "::set-output name=docs_changed::true"
+          else
+            echo "::set-output name=docs_changed::false"
+          fi
+
+  deploy-docs:
+    runs-on: ubuntu-latest
+    needs: check_docs_changes
+    if: needs.check_docs_changes.outputs.docs_changed == 'true'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,10 +12,14 @@ on:
 concurrency: build-and-deploy-${{ github.ref }}
 
 jobs:
-  check-for-doc-changes:
+  deploy-docs:
     runs-on: ubuntu-latest
+    needs: check-for-doc-changes 
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Check for changes in docs folder
         id: docs_check
         run: |
@@ -25,16 +29,8 @@ jobs:
             echo "docs_changed=false" >> $GITHUB_OUTPUT
           fi
 
-  deploy-docs:
-    runs-on: ubuntu-latest
-    needs: check-for-doc-changes 
-    if: needs.check-for-doc-changes.outputs.docs_changed == 'true'
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Deploy documentation
+        if: ${{ steps.docs_check.outputs.docs_changed == 'true' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docs

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Check for changes in docs folder
         id: docs_check
         run: |
-          if  [[ $(git diff --name-only ${{ github.event.repository.default_branch }} './docs') ]]; then
+          if  [[ $(git diff --name-only ${{ github.event.repository.default_branch }} -- './docs') ]]; then
             echo "There have been changes to the docs."
             echo "docs_changed=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Check for changes in docs folder
         id: docs_check
         run: |
+          git fetch origin/master
           if  [[ $(git diff --name-only origin/${{ github.event.repository.default_branch }} -- './docs') ]]; then
             echo "There have been changes to the docs."
             echo "docs_changed=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Check for changes in docs folder
         id: docs_check
         run: |
-          git fetch origin/master
-          if  [[ $(git diff --name-only origin/${{ github.event.repository.default_branch }} -- './docs') ]]; then
+          git fetch origin master
+          if  [[ $(git diff --name-only ${{ github.event.repository.default_branch }} -- './docs') ]]; then
             echo "There have been changes to the docs."
             echo "docs_changed=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check for changes in docs folder
         id: docs_check
         run: |
-	  if git diff --quiet HEAD^ HEAD --name-only | grep -q '^docs/'; then
+          if git diff --quiet HEAD^ HEAD --name-only | grep -q '^docs/'; then
             echo "::set-output name=docs_changed::true"
           else
             echo "::set-output name=docs_changed::false"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,14 +22,14 @@ jobs:
       - name: Check for changes in docs folder
         id: docs_check
         run: |
-          git fetch origin master
-          if  [[ $(git diff --name-only origin/${{ github.event.repository.default_branch }} -- './docs') ]]; then
-            echo "There have been changes to the docs."
-            echo "docs_changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "No changes to the docs."
-            echo "docs_changed=false" >> $GITHUB_OUTPUT
-          fi
+         git fetch origin master
+         if  [[ $(git diff --name-only origin/${{ github.event.repository.default_branch }} -- './docs') ]]; then
+           echo "There have been changes to the docs."
+           echo "docs_changed=true" >> $GITHUB_OUTPUT
+         else
+           echo "No changes to the docs."
+           echo "docs_changed=false" >> $GITHUB_OUTPUT
+         fi
 
       - name: Deploy documentation
         if: ${{ steps.docs_check.outputs.docs_changed == 'true' }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,8 +23,10 @@ jobs:
         id: docs_check
         run: |
           if  git diff --name-only FETCH_HEAD './docs'; then
+            echo "There have been changes to the docs."
             echo "docs_changed=true" >> $GITHUB_OUTPUT
           else
+            echo "No changes to the docs."
             echo "docs_changed=false" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -14,7 +14,6 @@ concurrency: build-and-deploy-${{ github.ref }}
 jobs:
   deploy-docs:
     runs-on: ubuntu-latest
-    needs: check-for-doc-changes 
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Check for changes in docs folder
         id: docs_check
         run: |
-          if git diff --name-only origin/master './docs'; then
+          if  git diff --name-only FETCH_HEAD './docs'; then
             echo "docs_changed=true" >> $GITHUB_OUTPUT
           else
             echo "docs_changed=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -28,7 +28,7 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-latest
     needs: check_docs_changes
-    if: needs.check_docs_changes.outputs.docs_changed == 'true'
+    if: needs.check-for-doc-changes.outputs.docs_changed == 'true'
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,7 +23,7 @@ jobs:
         id: docs_check
         run: |
           git fetch origin master
-          if  [[ $(git diff --name-only ${{ github.event.repository.default_branch }} -- './docs') ]]; then
+          if  [[ $(git diff --name-only origin/${{ github.event.repository.default_branch }} -- './docs') ]]; then
             echo "There have been changes to the docs."
             echo "docs_changed=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check for changes in docs folder
         id: docs_check
         run: |
-          if git diff --quiet HEAD^ HEAD --name-only | grep -q '^docs/'; then
+          if git diff --name-only master './docs'; then
             echo "docs_changed=true" >> $GITHUB_OUTPUT
           else
             echo "docs_changed=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -27,7 +27,7 @@ jobs:
 
   deploy-docs:
     runs-on: ubuntu-latest
-    needs: check_docs_changes
+    needs: check-for-doc-changes 
     if: needs.check-for-doc-changes.outputs.docs_changed == 'true'
 
     steps:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check for changes in docs folder
         id: docs_check
         run: |
-          if git diff --name-only master './docs'; then
+          if git diff --name-only origin/master './docs'; then
             echo "docs_changed=true" >> $GITHUB_OUTPUT
           else
             echo "docs_changed=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,9 +20,9 @@ jobs:
         id: docs_check
         run: |
           if git diff --quiet HEAD^ HEAD --name-only | grep -q '^docs/'; then
-            echo "::set-output name=docs_changed::true"
+            echo "docs_changed=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=docs_changed::false"
+            echo "docs_changed=false" >> $GITHUB_OUTPUT
           fi
 
   deploy-docs:


### PR DESCRIPTION
## Overview

This is fixing a mistake in #138. The logic in the workflow `build-and-deploy.yml` was flawed because you cannot use the `paths` option within a job. I was using that to try to check for changes to `./docs/*`.

## Solution

Instead, I have added an additional step that uses the command `git diff --name-only origin/master -- './docs'` to check if there are changes within the docs folder when the current branch (i.e. the pr branch) is compared to `origin/master`. 

Then if there have been changes we set an output that can be read later in the deploy documentation step like so:
```
        if: ${{ steps.docs_check.outputs.docs_changed == 'true' }}
```

## Testing

There isn't an easy way to test/validate this change for PRs. I've tested it by commiting test changes to this PR. So I am fairly certain it will work. But once we deploy this we can test that is working as changes go in. Needs be, I'll fix any additional problems.