### PR TITLE
Remove check for change in docs deploy

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,20 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Check for changes in docs folder
-        id: docs_check
-        run: |
-         git fetch origin master
-         if  [[ $(git diff --name-only origin/${{ github.event.repository.default_branch }} -- './docs') ]]; then
-           echo "There have been changes to the docs."
-           echo "docs_changed=true" >> $GITHUB_OUTPUT
-         else
-           echo "No changes to the docs."
-           echo "docs_changed=false" >> $GITHUB_OUTPUT
-         fi
-
       - name: Deploy documentation
-        if: ${{ steps.docs_check.outputs.docs_changed == 'true' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docs


### PR DESCRIPTION
## Overview

Removing the check for changes to the docs folder in the `build-and-deploy` workflow. Couldn't quite get this to work and it's not totally necessary. Probably we can sustain running the docs deploy each push to master. If this becomes a problem, we can revisit. The problem is definitely not insurmountable, just don't have the bandwidth to figure it out right now.