### PR TITLE
add example of :left and :right with two columns

### DIFF
--- a/notebooks/index.clj
+++ b/notebooks/index.clj
@@ -3915,6 +3915,13 @@ ds2
 
 
 (md "
+---
+")
+
+(tc/left-join ds2 ds1 {:left [:b :e] :right [:b :a]})
+
+
+(md "
 
 #### Right
 ")


### PR DESCRIPTION
Add an example to the documentation about how to use :left and :right when one of the column names differs.

See [this message](https://clojurians.zulipchat.com/#narrow/stream/151924-data-science/topic/tablecloth/near/432538950)

Here are the results of the join:

<img width="442" alt="image" src="https://github.com/scicloj/tablecloth/assets/847052/08d0f8d4-8135-42c5-aa19-51aeebfe9cb1">
