### PR TITLE
Fix sorting regression for non-numerical columns

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:extra-paths ["data"]
  :deps {org.clojure/clojure              {:mvn/version "1.11.1"}
-        techascent/tech.ml.dataset       {:mvn/version "7.029"}}
+        techascent/tech.ml.dataset       {:mvn/version "7.030"}}
  :aliases {:dev {:extra-deps {org.scicloj/clay {:mvn/version "2-beta11"}
                               org.scicloj/note-to-test {:mvn/version "1-alpha7"}}}
            :test {:extra-deps {org.scicloj/clay {:mvn/version "2-beta11"}

--- a/src/tablecloth/column/api/column.clj
+++ b/src/tablecloth/column/api/column.clj
@@ -88,10 +88,10 @@
                 (fn? order-or-comparator)))
      (throw (IllegalArgumentException.
              "`order-or-comparator` must be `:asc`, `:desc`, or a function.")))
-   (let [order-fn-lookup {:asc fun/<, :desc fun/>}
-         comparator-fn (if (fn? order-or-comparator)
-                         order-or-comparator
-                         (order-fn-lookup order-or-comparator)) 
+   (let [comparator-fn (cond
+                         (fn? order-or-comparator) order-or-comparator
+                         (= :asc order-or-comparator) compare
+                         (= :desc order-or-comparator) #(compare %2 %1))
          sorted-indices (argsort comparator-fn col)]
      (col/select col sorted-indices))))
 


### PR DESCRIPTION
Upgrade TMD to the latest version by fixing a regression. this code uses tech.v3.datatype.functional/< or tech.v3.datatype.functional/> to sort columns which no longer works if types are not numerical. Should be replaced with clojure comparator (similar to tablecloth.api.order-by namespace)