### PR TITLE
Treat bindings in let-dataset as columns

### DIFF
--- a/src/tablecloth/api/api_template.clj
+++ b/src/tablecloth/api/api_template.clj
@@ -111,7 +111,7 @@
                          pivot->longer
                          pivot->wider)
 
-(exporter/export-symbols tablecloth.api.join-concat-ds                         
+(exporter/export-symbols tablecloth.api.join-concat-ds
                          left-join
                          right-join
                          inner-join
@@ -166,7 +166,7 @@
   ([bindings] `(let-dataset ~bindings nil))
   ([bindings options]
    (let [cols (take-nth 2 bindings)
-         col-defs (mapv vector (map keyword cols) cols)]
+         col-defs (into (array-map) (map vector (map keyword cols) cols))]
      `(let [~@bindings]
         (dataset ~col-defs ~options)))))
 

--- a/test/tablecloth/api/dataset_test.clj
+++ b/test/tablecloth/api/dataset_test.clj
@@ -1,5 +1,6 @@
 (ns tablecloth.api.dataset-test
   (:require [tablecloth.api :as api]
+            [tablecloth.column.api :as tcc]
             [tablecloth.common-test :refer [DS]]
             [clojure.java.io :as io]
             [midje.sweet :refer [tabular fact => throws]])
@@ -128,3 +129,9 @@
                ?f ?v
                api/rows  '((1.0 5.0) (2.0 6.0) (3.0 7.0))
                api/columns '((1.0 2.0 3.0) (5.0 6.0 7.0))))
+
+(fact "let-dataset"
+      (fact (api/let-dataset [x (range 4) y 10 z (tcc/+ x y)])
+            => (api/dataset {:x [0 1 2 3]
+                             :y [10 10 10 10]
+                             :z [10 11 12 13]})))


### PR DESCRIPTION
A fix for the issue described [here](https://clojurians.zulipchat.com/#narrow/stream/236259-tech.2Eml.2Edataset.2Edev/topic/Questions.20about.20the.20.60let-dataset.60.20macro.20in.20Tablecloth) where `let-dataset` appeared to be treating its bindings as rows rather than columns.