### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+docs/** linguist-documentation
+pr-preview/** linguist-documentation


### PR DESCRIPTION
This fixes the languages section to show Clojure primarily