### PR TITLE
Corrected a typo – from ":MULTIPY" to ":MULTIPLY"

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6867,7 +6867,7 @@ window.Quarto = {
 </div>
 <div class="sourceClojure">
 <div class="sourceCode" id="cb207"><pre class="sourceCode clojure code-with-copy"><code class="sourceCode clojure"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a>(<span class="kw">-&gt;</span> DS</span>
-<span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a>    (tc/* <span class="at">:MULTIPY</span> [<span class="at">:V1</span> <span class="at">:V2</span>]))</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a>    (tc/* <span class="at">:MULTIPLY</span> [<span class="at">:V1</span> <span class="at">:V2</span>]))</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
 </div>
 <div class="clay-dataset">
 <p>_unnamed [9 5]:</p>
@@ -6878,7 +6878,7 @@ window.Quarto = {
 <th style="text-align: right;">:V2</th>
 <th style="text-align: right;">:V3</th>
 <th>:V4</th>
-<th style="text-align: right;">:MULTIPY</th>
+<th style="text-align: right;">:MULTIPLY</th>
 </tr>
 </thead>
 <tbody>

--- a/notebooks/index.clj
+++ b/notebooks/index.clj
@@ -1625,7 +1625,7 @@ DS
     (tc/+ :SUM [:V1 :V2]))
 
 (-> DS
-    (tc/* :MULTIPY [:V1 :V2]))
+    (tc/* :MULTIPLY [:V1 :V2]))
 
 
 ;; Now let's look at operations that would return a scalar:


### PR DESCRIPTION
Super tiny correction. It was confusing when searching for the section with "multiply" (I remembered it was there from weeks ago but search found zero results :).