### PR TITLE
allow set as seq for dataset creation

### DIFF
--- a/src/tablecloth/api/dataset.clj
+++ b/src/tablecloth/api/dataset.clj
@@ -50,7 +50,9 @@
 
 (defn- from-tensor
   [data column-names layout dataset-name]
-  (let [t (tensor/->tensor data)
+  (let [t (tensor/->tensor (if (set? data)
+                             (seq data)
+                             data))
         t (-> (if (= layout :as-columns) (tensor/transpose t [1 0]) t)
               (ds-tensor/tensor->dataset dataset-name))]
     (if column-names
@@ -69,6 +71,7 @@
   * sequence of columns
   * file or url
   * array of arrays
+  * sequence of sequences
   * single value
 
   Single value is set only when it's not possible to find a path for given data. If tech.ml.dataset throws an exception, it's won;t be printed. To print a stack trace, set `stack-trace?` option to `true`.


### PR DESCRIPTION
tensors can be created with seqs, but not sets

See discussion [#tech.ml.dataset.dev > feature request: -&gt;dataset accept set of vectors](https://clojurians.zulipchat.com/#narrow/channel/236259-tech.2Eml.2Edataset.2Edev/topic/feature.20request.3A.20-.3Edataset.20accept.20set.20of.20vectors/with/613895147)